### PR TITLE
Feature/jacocoTestReport gradle task

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -142,7 +142,7 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'crea
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
     def debugTree = fileTree(dir: "${buildDir}/intermediates/classes/debug", excludes: fileFilter)
     def kotlinDebugTree = fileTree(dir: "${buildDir}/tmp/kotlin-classes/debug", excludes: fileFilter)
-    def mainSrc = "${project.projectDir}/src/androidTest/java"
+    def mainSrc = "${project.projectDir}/src/main/java"
 
     sourceDirectories.from = files([mainSrc])
     classDirectories.from = files([debugTree], [kotlinDebugTree])


### PR DESCRIPTION
Added jacocoTestReport task that generates test coverage report.

Running: .`/gradlew jacocoTestReport`

Report location: `build->reports->jacoco->jacocoTestReport->html->index.html`

![test_report](https://user-images.githubusercontent.com/15632654/65492015-76305480-deb0-11e9-9dd0-7deffb65447e.png)
