### PR TITLE
Bugfix/Audio node: fixes in exception handling

### DIFF
--- a/android/src/main/java/com/magicleap/magicscript/scene/nodes/audio/AudioNode.kt
+++ b/android/src/main/java/com/magicleap/magicscript/scene/nodes/audio/AudioNode.kt
@@ -100,12 +100,7 @@ open class AudioNode @JvmOverloads constructor(
             audioEngine.unloadSoundFile(file.path)
         }
 
-        try {
-            audioThread?.interrupt()
-        } catch (e: SecurityException) {
-            logMessage(e.toString(), true)
-        }
-
+        audioThread?.interrupt()
         audioThread = null
         audioEngineSet = false
 

--- a/android/src/main/java/com/magicleap/magicscript/utils/FileDownloader.kt
+++ b/android/src/main/java/com/magicleap/magicscript/utils/FileDownloader.kt
@@ -76,11 +76,7 @@ class FileDownloader(private val context: Context) {
     }
 
     fun onDestroy() {
-        try {
-            threads.values.forEach { it.interrupt() }
-        } catch (e: SecurityException) {
-            logMessage(e.toString(), true)
-        }
+        threads.values.forEach { it.interrupt() }
         threads.clear()
     }
 
@@ -98,11 +94,7 @@ class FileDownloader(private val context: Context) {
             file: File
     ) {
         result(file)
-        try {
-            threads[path]?.interrupt()
-        } catch (e: SecurityException) {
-            logMessage(e.toString(), true)
-        }
+        threads[path]?.interrupt()
         threads.remove(path)
     }
 }


### PR DESCRIPTION
Fix for #282  - we must catch exceptions for each thread separately. Also, when logging exceptions, we usually should usually use `e.toString`, because `e.message` / `localizedMessage` may be null.