### PR TITLE
Feature/Forcing same items size for listview

### DIFF
--- a/android/src/main/java/com/magicleap/magicscript/scene/nodes/UiListViewItemNode.kt
+++ b/android/src/main/java/com/magicleap/magicscript/scene/nodes/UiListViewItemNode.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Bundle
 import android.view.View
 import com.facebook.react.bridge.ReadableMap
-import com.google.ar.sceneform.Node
 import com.google.ar.sceneform.math.Vector3
 import com.magicleap.magicscript.ar.ViewRenderableLoader
 import com.magicleap.magicscript.scene.nodes.base.Layoutable
@@ -15,6 +14,7 @@ import com.magicleap.magicscript.utils.PropertiesReader
 import com.magicleap.magicscript.utils.Vector2
 import com.magicleap.magicscript.utils.logMessage
 import com.magicleap.magicscript.utils.putDefault
+import kotlin.math.max
 
 open class UiListViewItemNode(
     initProps: ReadableMap,
@@ -29,6 +29,12 @@ open class UiListViewItemNode(
 
         val DEFAULT_BACKGROUND_COLOR = arrayListOf(0.0, 0.0, 0.0, 0.0)
     }
+
+    var minSize = Vector2(0f, 0f)
+        set(value) {
+            field = value
+            setNeedsRebuild(true)
+        }
 
     private var lastContentBounds = Bounding()
 
@@ -45,7 +51,9 @@ open class UiListViewItemNode(
     }
 
     override fun provideDesiredSize(): Vector2 {
-        return lastContentBounds.size()
+        val width = max(lastContentBounds.size().x, minSize.x)
+        val height = max(lastContentBounds.size().y, minSize.y)
+        return Vector2(width, height)
     }
 
     override fun applyProperties(props: Bundle) {

--- a/android/src/main/java/com/magicleap/magicscript/scene/nodes/UiListViewNode.kt
+++ b/android/src/main/java/com/magicleap/magicscript/scene/nodes/UiListViewNode.kt
@@ -55,6 +55,7 @@ open class UiListViewNode(
 
         onContentSizeChangedListener = { contentSize ->
             this.contentSize = contentSize
+            forceSameItemsWidth()
 
             val size = readSize()
 
@@ -119,5 +120,19 @@ open class UiListViewNode(
         val width = properties.getDouble(PROP_WIDTH, WRAP_CONTENT_DIMENSION.toDouble())
         val height = properties.getDouble(PROP_HEIGHT, WRAP_CONTENT_DIMENSION.toDouble())
         return Vector2(width.toFloat(), height.toFloat())
+    }
+
+    private fun forceSameItemsWidth() {
+        val orientation = properties.getString(PROP_ORIENTATION, DEFAULT_ORIENTATION)
+        val minItemSize = if (orientation == ORIENTATION_VERTICAL) {
+            Vector2(contentSize.x, 0f)
+        } else {
+            Vector2(0f, contentSize.y)
+        }
+        containerNode.childrenList
+            .filterIsInstance<UiListViewItemNode>()
+            .forEach { item ->
+                item.minSize = minItemSize
+            }
     }
 }


### PR DESCRIPTION
According to Lumin all list items should have equal width.

![same_items_size](https://user-images.githubusercontent.com/15632654/70732511-8b11cc80-1cd6-11ea-9d4e-bfe89f54784f.png)
