### PR TITLE
Bugfix/Dropdown item id as String for Android

### DIFF
--- a/components/platform/platform-factory.js
+++ b/components/platform/platform-factory.js
@@ -118,6 +118,8 @@ export class PlatformFactory extends NativeFactory {
             properties['text'] = child.toString();
         }
 
+        // For Android we have to change the type of id property to String,
+        // because React internally expects it (without this the DropdownListItem crashed).
         const isAndroid = Platform.OS === 'android';
         const modifiedId = isAndroid ? `${properties.id}` : properties.id;
         

--- a/components/platform/platform-factory.js
+++ b/components/platform/platform-factory.js
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 Magic Leap, Inc. All Rights Reserved
 
-import { Image, NativeEventEmitter, NativeModules, processColor } from 'react-native';
+import { Image, NativeEventEmitter, NativeModules, Platform, processColor } from 'react-native';
 import { NativeFactory } from '../core/native-factory';
 import generateId from '../utils/generateId';
 import { Log } from '../utils/logger';
@@ -118,6 +118,9 @@ export class PlatformFactory extends NativeFactory {
             properties['text'] = child.toString();
         }
 
+        const isAndroid = Platform.OS === 'android';
+        const modifiedId = isAndroid ? `${properties.id}` : properties.id;
+        
         return ({
             ...properties,
             ...(properties.color ? { color: this._processColor(properties.color) } : {}),
@@ -126,6 +129,7 @@ export class PlatformFactory extends NativeFactory {
             ...(properties.filePath ? { filePath: this._processAssetSource(properties.filePath) } : {}),
             ...(properties.videoPath ? { videoPath: this._processAssetSource(properties.videoPath) } : {}),
             ...(properties.fileName ? { fileName: this._processAssetSource(properties.fileName) } : {}),
+            ...(properties.id ? { id: modifiedId } : {}),
         });
     }
 


### PR DESCRIPTION
React internally expects that `id` must be String on Android.