### PR TITLE
Add support for XRKit on Android

### DIFF
--- a/android/src/main/java/com/magicleap/magicscript/scene/UiNodesManager.kt
+++ b/android/src/main/java/com/magicleap/magicscript/scene/UiNodesManager.kt
@@ -93,6 +93,9 @@ open class UiNodesManager : NodesManager, LifecycleEventListener {
             logMessage("cannot add node: not found")
             return
         }
+        if (tryAddNodeToAnchor(node)) {
+            return
+        }
         rootNode.addChild(node)
     }
 
@@ -105,11 +108,28 @@ open class UiNodesManager : NodesManager, LifecycleEventListener {
             logMessage("cannot add node: not found")
             return
         }
+        if (tryAddNodeToAnchor(node)) {
+            return
+        }
         if (parentNode == null) {
             logMessage("cannot add node: parent not found")
             return
         }
         parentNode.addContent(node)
+    }
+
+    private fun tryAddNodeToAnchor(node: TransformNode): Boolean {
+        if (node.anchorUuid.isEmpty()) {
+            return false
+        }
+        val anchorNode = scene.findByName(node.anchorUuid)
+        return if (anchorNode is AnchorNode) {
+            anchorNode.addChild(node)
+            true
+        } else {
+            logMessage("tryAddNodeToAnchor anchorUuid not found: ${node.anchorUuid}")
+            false
+        }
     }
 
     @Synchronized

--- a/android/src/main/java/com/magicleap/magicscript/scene/nodes/base/TransformNode.kt
+++ b/android/src/main/java/com/magicleap/magicscript/scene/nodes/base/TransformNode.kt
@@ -52,6 +52,7 @@ abstract class TransformNode(
         const val PROP_LOCAL_ROTATION = "localRotation"
         const val PROP_LOCAL_TRANSFORM = "localTransform"
         const val PROP_ALIGNMENT = "alignment"
+        const val PROP_ANCHOR_UUID = "anchorUuid"
 
         /**
          * Indicates how often we measure bounding and (if necessary)
@@ -68,6 +69,9 @@ abstract class TransformNode(
      * Renderable and / or child nodes should be added to it.
      */
     val contentNode = Node()
+
+    var anchorUuid: String = ""
+        private set
 
     /**
      * Alignment used to position a Renderable or [contentNode]
@@ -308,6 +312,7 @@ abstract class TransformNode(
         setLocalRotation(props)
         setLocalTransform(props)
         setAlignment(props)
+        setAnchorUuid(props)
     }
 
     /**
@@ -368,6 +373,12 @@ abstract class TransformNode(
         contentNode.localPosition = Vector3(x, y, contentNode.localPosition.z)
     }
 
+    private fun setAnchorUuid(props: Bundle) {
+        val anchorUuid = props.read<String>(PROP_ANCHOR_UUID)
+        if (anchorUuid != null) {
+            this.anchorUuid = anchorUuid;
+        }
+    }
 
     private fun setLocalPosition(props: Bundle) {
         val registeredParent = parent?.parent // first parent is a content node

--- a/ios/RNMagicScript/components/BaseNodes/TransformNode.swift
+++ b/ios/RNMagicScript/components/BaseNodes/TransformNode.swift
@@ -47,7 +47,7 @@ import SceneKit
         get { return self.transform }
         set { self.transform = newValue; setNeedsLayout() }
     }
-    @objc var anchorUuid: String = "rootUuid";
+    @objc var anchorUuid: String = "";
     // var cursorHoverState: CursorHoverState // ignore in mobile
     // var offset: SCNVector3 // ???
     @objc var debug: Bool = false {

--- a/ios/RNMagicScriptTests/sources/specs/Utils/UiNodesManagerSpec.swift
+++ b/ios/RNMagicScriptTests/sources/specs/Utils/UiNodesManagerSpec.swift
@@ -42,7 +42,7 @@ class UiNodesManagerSpec: QuickSpec {
                     
                     let localReferenceNode = UiButtonNode()
                     let localReferenceNodeId = "referenceNodeId"
-                    nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [localReferenceNodeId: localReferenceNode], nodeByAnchorUuid: [:], focusedNode: focusedNode)
+                    nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [localReferenceNodeId: localReferenceNode], transformNodeByAnchorUuid: [:], anchorNodeByAnchorUuid: [:], focusedNode: focusedNode)
                     nodesManager.onInputUnfocused = {
                         
                     }
@@ -54,14 +54,14 @@ class UiNodesManagerSpec: QuickSpec {
             
             context("when asked for node by ID") {
                 it("should return node when exists") {
-                    nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [referenceNodeId: referenceNode], nodeByAnchorUuid: [:], focusedNode: nil)
+                    nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [referenceNodeId: referenceNode], transformNodeByAnchorUuid: [:], anchorNodeByAnchorUuid: [:], focusedNode: nil)
                     
                     let result = nodesManager.findNodeWithId(referenceNodeId)
                     expect(result).to(beIdenticalTo(referenceNode))
                 }
                 
                 it("should return nil when node doesnt exist") {
-                    nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [:], nodeByAnchorUuid: [:], focusedNode: nil)
+                    nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [:], transformNodeByAnchorUuid: [:], anchorNodeByAnchorUuid: [:], focusedNode: nil)
                     
                     let result = nodesManager.findNodeWithId(referenceNodeId)
                     expect(result).to(beNil())
@@ -70,14 +70,14 @@ class UiNodesManagerSpec: QuickSpec {
             
             context("when asked for node by Anchor UUID") {
                 it("should return node when exists") {
-                    nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [:], nodeByAnchorUuid: [referenceNodeId: referenceNode], focusedNode: nil)
+                    nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [:], transformNodeByAnchorUuid: [referenceNodeId: referenceNode], anchorNodeByAnchorUuid: [:], focusedNode: nil)
                     
                     let result = nodesManager.findNodeWithAnchorUuid(referenceNodeId)
                     expect(result).to(beIdenticalTo(referenceNode))
                 }
                 
                 it("should return nil when node doesnt exist") {
-                    nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [:], nodeByAnchorUuid: [:], focusedNode: nil)
+                    nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [:], transformNodeByAnchorUuid: [:], anchorNodeByAnchorUuid: [:], focusedNode: nil)
                     
                     let result = nodesManager.findNodeWithAnchorUuid(referenceNodeId)
                     expect(result).to(beNil())
@@ -86,7 +86,7 @@ class UiNodesManagerSpec: QuickSpec {
             
             context("when registering node") {
                 it("node should be stored (by ID)") {
-                    nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [:], nodeByAnchorUuid: [:], focusedNode: nil)
+                    nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [:], transformNodeByAnchorUuid: [:], anchorNodeByAnchorUuid: [:], focusedNode: nil)
                     
                     nodesManager.registerNode(referenceNode, nodeId: referenceNodeId)
                     
@@ -98,7 +98,7 @@ class UiNodesManagerSpec: QuickSpec {
                 context("when anchor UUID set (different than rootUuid)") {
                     it("node should be stored (by UUID)") {
                         referenceNode.anchorUuid = referenceAnchorUUID
-                        nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [:], nodeByAnchorUuid: [:], focusedNode: nil)
+                        nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [:], transformNodeByAnchorUuid: [:], anchorNodeByAnchorUuid: [:], focusedNode: nil)
                         
                         nodesManager.registerNode(referenceNode, nodeId: referenceNodeId)
                         
@@ -111,7 +111,7 @@ class UiNodesManagerSpec: QuickSpec {
             context("when asked to unregister node") {
                 context("when node exists in store (by ID)") {
                     it("should be removed from storage") {
-                        nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [referenceNodeId: referenceNode], nodeByAnchorUuid: [:], focusedNode: nil)
+                        nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [referenceNodeId: referenceNode], transformNodeByAnchorUuid: [:], anchorNodeByAnchorUuid: [:], focusedNode: nil)
                         nodesManager.unregisterNode(referenceNodeId)
                         
                         let result = nodesManager.findNodeWithId(referenceNodeId)
@@ -119,7 +119,7 @@ class UiNodesManagerSpec: QuickSpec {
                     }
                     
                     it("should be removed from parent") {
-                        nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [referenceNodeId: referenceNode], nodeByAnchorUuid: [:], focusedNode: nil)
+                        nodesManager = UiNodesManager(rootNode: TransformNode(), nodesById: [referenceNodeId: referenceNode], transformNodeByAnchorUuid: [:], anchorNodeByAnchorUuid: [:], focusedNode: nil)
                         let parentNode = SCNNode(geometry: SCNGeometry(sources: [], elements: nil))
                         parentNode.addChildNode(referenceNode)
                         
@@ -139,7 +139,8 @@ class UiNodesManagerSpec: QuickSpec {
                     
                     nodesManager = UiNodesManager(rootNode: TransformNode(),
                                                   nodesById: [referenceNodeId: referenceNode, parentRreferenceNodeId: parentReferenceNode],
-                                                  nodeByAnchorUuid: [:],
+                                                  transformNodeByAnchorUuid: [:],
+                                                  anchorNodeByAnchorUuid: [:],
                                                   focusedNode: nil)
                     nodesManager.addNode(referenceNodeId, toParent: parentRreferenceNodeId)
                     expect(parentReferenceNode.contentNode.childNodes).to(contain(referenceNode))
@@ -152,7 +153,8 @@ class UiNodesManagerSpec: QuickSpec {
                     
                     nodesManager = UiNodesManager(rootNode: TransformNode(),
                                                   nodesById: [referenceNodeId: referenceNode, parentRreferenceNodeId: parentReferenceNode],
-                                                  nodeByAnchorUuid: [:],
+                                                  transformNodeByAnchorUuid: [:],
+                                                  anchorNodeByAnchorUuid: [:],
                                                   focusedNode: nil)
                     nodesManager.removeNode(referenceNodeId, fromParent: parentRreferenceNodeId)
                     expect(parentReferenceNode.contentNode.childNodes).toNot(contain(referenceNode))
@@ -164,7 +166,8 @@ class UiNodesManagerSpec: QuickSpec {
                     let rootRefereneceNode = TransformNode()
                     nodesManager = UiNodesManager(rootNode: rootRefereneceNode,
                                                   nodesById: [referenceNodeId: referenceNode],
-                                                  nodeByAnchorUuid: [:],
+                                                  transformNodeByAnchorUuid: [:],
+                                                  anchorNodeByAnchorUuid: [:],
                                                   focusedNode: nil)
                     
                     nodesManager.addNodeToRoot(referenceNodeId)
@@ -176,7 +179,8 @@ class UiNodesManagerSpec: QuickSpec {
                     rootRefereneceNode.addChildNode(referenceNode)
                     nodesManager = UiNodesManager(rootNode: rootRefereneceNode,
                                                   nodesById: [referenceNodeId: referenceNode],
-                                                  nodeByAnchorUuid: [:],
+                                                  transformNodeByAnchorUuid: [:],
+                                                  anchorNodeByAnchorUuid: [:],
                                                   focusedNode: nil)
                     
                     nodesManager.removeNodeFromRoot(referenceNodeId)
@@ -190,7 +194,8 @@ class UiNodesManagerSpec: QuickSpec {
                     rootRefereneceNode.addChildNode(referenceNode)
                     nodesManager = UiNodesManager(rootNode: rootRefereneceNode,
                                                   nodesById: [referenceNodeId: referenceNode],
-                                                  nodeByAnchorUuid: [:],
+                                                  transformNodeByAnchorUuid: [:],
+                                                  anchorNodeByAnchorUuid: [:],
                                                   focusedNode: nil)
                     
                     nodesManager.clear()
@@ -208,7 +213,8 @@ class UiNodesManagerSpec: QuickSpec {
                 it("whould do nothing when node doesn't exist in storage") {
                     nodesManager = UiNodesManager(rootNode: TransformNode(),
                                                   nodesById: [referenceNodeId: referenceNode],
-                                                  nodeByAnchorUuid: [:],
+                                                  transformNodeByAnchorUuid: [:],
+                                                  anchorNodeByAnchorUuid: [:],
                                                   focusedNode: nil)
                     
                     let result = nodesManager.updateNode(referenceNodeId, properties: ["visible" : true])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-script-components-react-native",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Magic Script Components package for React Native.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In order to make the Android implementation easier, the order in which XrClientBridge.createAnchor and rendering of anchored content should occur has been swapped.

With the new implementation, createAnchor must be called first. The anchor will then be looked up when the content is rendered.